### PR TITLE
Fix: Remove 'x' group from regex and destructuring

### DIFF
--- a/src/commonMain/kotlin/Core.kt
+++ b/src/commonMain/kotlin/Core.kt
@@ -99,7 +99,7 @@ object Core {
         }
     }
 
-    val rowRegex = "(?<name>.+)\\t(?<timestamp>.+)\\t(?<x>.+)\\t(?<count>\\d+).*".toRegex()
+    val rowRegex = "(?<name>.+)\\t(?<timestamp>.+)\\t(?<count>\\d+).*".toRegex()
 
     fun String.toTable(filters: List<BaseFilter>): Map<String, List<PivotTableRow>> {
         val rows = mutableMapOf<String, MutableList<PivotTableRow>>()
@@ -108,7 +108,7 @@ object Core {
             .filter { line -> line.isNotBlank() }
             .forEach { line ->
                 rowRegex.find(line)?.let {
-                    val (name, timestamp, _, count) = it.destructured
+                    val (name, timestamp, count) = it.destructured
                     val filteredName = name.apply(filters)
                     if (filteredName != null) {
                         val list = rows.getOrPut(


### PR DESCRIPTION
## Fix: Remove `x` Column Parsing and Regex Group from Core.kt

### Summary

This PR updates the parsing logic in `src/commonMain/kotlin/Core.kt` to address errors caused by the absence of the `x` column in the extracted text.  That is due to the fact that pivot table text does not contain SUM(thread) for both the Canary and Stable versions of Perfetto. See #3 bug for more information. 

Specifically, it:
- Modifies the `rowRegex` to ignore the `x` group, matching only `name`, `timestamp`, and `count` columns.
- Updates the destructuring assignment from `val (name, timestamp, _, count)` to `val (name, timestamp, count)`, thus removing the unused variable for the `x` group.

### Details

- The previous regex expected an `x` column which no longer exists in the data, causing runtime errors.
- The new regex and destructuring are now aligned with the actual data format, ensuring robust parsing.

### Before & After

| Before | After |
|--------|-------|
| <img width="634" alt="Screenshot 2025-06-07 at 11 04 58 PM" src="https://github.com/user-attachments/assets/7c60b2e5-47fd-44f0-9902-4b6ea045e98d" /> | <img width="1439" alt="Screenshot 2025-06-07 at 11 07 08 PM" src="https://github.com/user-attachments/assets/41648592-a0fc-46e4-acd9-c1e2d4c9df8b" /> |
| <img width="805" alt="Screenshot 2025-06-07 at 11 05 09 PM" src="https://github.com/user-attachments/assets/0c49c88f-22a7-4128-b0f8-0be2b6ff505f" /> | <img width="1437" alt="Screenshot 2025-06-07 at 11 07 16 PM" src="https://github.com/user-attachments/assets/b564805b-a8c9-48ae-973f-5914155bb273" /> |

---

Closes #3